### PR TITLE
nodeenv 1.9.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/nodeenv-{{ version }}.tar.gz
   sha256: 6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f
+  patches:
+    # Update 1: patch still needed.
+    - tests_windows.patch  # [win]
 
 build:
   number: 0
@@ -20,6 +23,8 @@ build:
   skip: True  # [py<37]
 
 requirements:
+  build:
+    - m2-patch  # [win]
   host:
     - pip
     - python
@@ -48,13 +53,19 @@ test:
 
 about:
   home: https://ekalinin.github.io/nodeenv/
+  summary: Node.js virtual environment builder
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: Node.js virtual environment builder
+  description: |
+    nodeenv (node.js virtual environment) is a tool to create isolated node.js environments.
+    It creates an environment that has its own installation directories, that doesn't share libraries with other node.js virtual environments.
+    Also new environment can be integrated with environment which was built by virtualenv (python).
   dev_url: https://github.com/ekalinin/nodeenv
-  doc_url: https://github.com/ekalinin/nodeenv
+  doc_url: https://github.com/ekalinin/nodeenv/blob/master/README.rst
 
 extra:
   recipe-maintainers:
     - nicoddemus
+  skip-lints:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/nodeenv-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f
   patches:
     # Update 1: patch still needed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,51 +1,50 @@
 {% set name = "nodeenv" %}
-{% set version = "1.7.0" %}
+{% set version = "1.9.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/ekalinin/nodeenv/archive/{{ version }}.tar.gz
-  sha256: a9e9e36e1be6439e877c53e7f27ce068f75b82cc08201f2c68471687199cfd7b
-  patches:
-    - tests_windows.patch  # [win]
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/nodeenv-{{ version }}.tar.gz
+  sha256: 6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f
 
 build:
   number: 0
-  skip: True  # [py<37]
+  # Need to avoid error: setuptools-scm was unable to detect version !!!
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   entry_points:
     - nodeenv = nodeenv:main
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<37]
 
 requirements:
-  build:
-    - m2-patch # [win]
   host:
     - pip
     - python
-    - setuptools
     - wheel
+    - setuptools
+    - setuptools-scm
   run:
     - python
     - setuptools  # depends on pkg_resources at runtime
 
 test:
+  source_files:
+    - tests
+  imports:
+    - nodeenv
   commands:
     - pip check
     - nodeenv --help
-    # skip test_smoke because nodejs fails with:
-    #   nodejs: /lib64/libc.so.6: version `GLIBC_2.16' not found (required by nodejs)
-    # let's assume it's an issue with the docker image
-    - pytest tests -ra -k "not test_smoke"
+    # Skip test_smoke: https://github.com/ekalinin/nodeenv/issues/360
+    - pytest -vv tests -ra -k "not test_smoke"
   requires:
     - pip
     - pytest
     - mock
     - coverage
-  source_files:
-    - tests
 
 about:
   home: https://ekalinin.github.io/nodeenv/


### PR DESCRIPTION
nodeenv 1.9.1 

**Destination channel:** Defaults

### Links

- [PKG-7148]
- dev_url:        https://github.com/ekalinin/nodeenv/tree/1.9.1
- conda_forge:    https://github.com/conda-forge/nodeenv-feedstock
- pypi:           https://pypi.org/project/nodeenv/1.9.1
- pypi inspector: https://inspector.pypi.io/project/nodeenv/1.9.1

### Explanation of changes:

- new version number


[PKG-7148]: https://anaconda.atlassian.net/browse/PKG-7148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ